### PR TITLE
update server installer to be more error resilient, fix concurrency issues

### DIFF
--- a/plebnet/agent/config.py
+++ b/plebnet/agent/config.py
@@ -28,6 +28,7 @@ class PlebNetConfig(object):
                        "excluded_providers": ["linevast"],
                        "chosen_provider": None,
                        "bought": [],
+                       "installing": [],
                        "installed": [],
                        "transactions": []}
         self.load()

--- a/plebnet/agent/qtable.py
+++ b/plebnet/agent/qtable.py
@@ -126,6 +126,7 @@ class QTable:
                 candidate["provider_name"] = provider
                 candidate["option_name"] = self.find_offer(offer_name, provider)
 
+        # TODO: Handle an edge case when cloudomate fails and options returns an empty array
         options = cloudomate_controller.options(providers[candidate["provider_name"]])
 
         for i, option in enumerate(options):

--- a/plebnet/controllers/market_controller.py
+++ b/plebnet/controllers/market_controller.py
@@ -39,6 +39,7 @@ def get_balance(domain):
     :return: the balance
     """
     try:
+        # TODO: Find out how to get balance using only confirmed transactions
         r = requests.get('http://localhost:8085/wallets/' + domain + '/balance')
         balance = r.json()
         return balance['balance']['available']

--- a/tests/clone/test_server_installer.py
+++ b/tests/clone/test_server_installer.py
@@ -63,7 +63,7 @@ class TestServerInstaller(unittest.TestCase):
     def test_is_valid_ip_no_number(self):
         self.assertFalse(server_installer.is_valid_ip('120.0.1.a'))
 
-    @mock.patch('plebnet.clone.server_installer._install_server', return_value=False)
+    @mock.patch('plebnet.clone.server_installer._install_server', return_value=True)
     @mock.patch('plebnet.controllers.cloudomate_controller.get_ip', return_value='120.21.0.12')
     @mock.patch('plebnet.controllers.cloudomate_controller.child_account', return_value=test_account)
     @mock.patch('cloudomate.hoster.vps.linevast.LineVast.enable_tun_tap', return_value=False)


### PR DESCRIPTION
This PR addresses a couple of edge cases that could occur during the VPS installation process.

- When VPS installation starts, it is moved from the `bought` to `installing` array, so the installation is not started for the second time on subsequent `plebnet check` invocation when it takes too long.

- When the first purchased server is not ready yet, we check other bought servers.

- When VPS installation fails, it is moved to the end of the `bought` array.

- When VPN is found in bought array, it is skipped, rather then stopping the installation process.

- Even if VPN info cannot be downloaded, we still proceed to VPS installation. This needs better error handling in future, but for that we need more information about the error from Cloudomate. (Currently we cannot tell if VPN is just not ready yet or Cloudomate is broken.)